### PR TITLE
Using get_assertion_info instead of decode_json_bytes to read audience

### DIFF
--- a/vep/verifiers/remote.py
+++ b/vep/verifiers/remote.py
@@ -36,7 +36,7 @@
 
 import json
 
-from vep.utils import secure_urlopen, decode_json_bytes
+from vep.utils import secure_urlopen, get_assertion_info
 from vep.errors import (InvalidSignatureError,
                         ConnectionError,
                         AudienceMismatchError)
@@ -80,8 +80,7 @@ class RemoteVerifier(object):
         # Read audience from assertion if not specified.
         if audience is None:
             try:
-                token = decode_json_bytes(assertion)["assertion"]
-                audience = decode_json_bytes(token.split(".")[1])["aud"]
+                audience = get_assertion_info(assertion)["audience"]
             except (KeyError, IndexError):
                 raise ValueError("Malformed JWT")
         # Encode the data into x-www-form-urlencoded.

--- a/vep/verifiers/remote.py
+++ b/vep/verifiers/remote.py
@@ -82,9 +82,9 @@ class RemoteVerifier(object):
         # Read audience from assertion if not specified.
         if audience is None:
             try:
-                _, assertion = unbundle_certs_and_assertion(assertion)
+                _, unbundled = unbundle_certs_and_assertion(assertion)
                 # Get the audience out of the assertion token.
-                payload = decode_json_bytes(assertion.split(".")[1])
+                payload = decode_json_bytes(unbundled.split(".")[1])
                 audience = payload["aud"]
             except (KeyError, IndexError):
                 raise ValueError("Malformed JWT")

--- a/vep/verifiers/remote.py
+++ b/vep/verifiers/remote.py
@@ -36,7 +36,9 @@
 
 import json
 
-from vep.utils import secure_urlopen, get_assertion_info
+from vep.utils import (secure_urlopen,
+                       decode_json_bytes,
+                       unbundle_certs_and_assertion)
 from vep.errors import (InvalidSignatureError,
                         ConnectionError,
                         AudienceMismatchError)
@@ -80,7 +82,10 @@ class RemoteVerifier(object):
         # Read audience from assertion if not specified.
         if audience is None:
             try:
-                audience = get_assertion_info(assertion)["audience"]
+                _, assertion = unbundle_certs_and_assertion(assertion)
+                # Get the audience out of the assertion token.
+                payload = decode_json_bytes(assertion.split(".")[1])
+                audience = payload["aud"]
             except (KeyError, IndexError):
                 raise ValueError("Malformed JWT")
         # Encode the data into x-www-form-urlencoded.


### PR DESCRIPTION
Using decode_json_bytes here seemed to be struggling (tested with a repoze.who.plugins.browserid setup) to read the assertion. As far as I can tell, this utility should provide the same behaviour and remedies the issue for me.
